### PR TITLE
Fixed bug for PHP example

### DIFF
--- a/examples/php/example.php
+++ b/examples/php/example.php
@@ -82,10 +82,19 @@ class Bl3pApi {
 		if (!$result) {
 			throw new Exception("API request failed: Invalid JSON-data received: ".substr($res,0,100));
 		}
+		
+		if(!array_key_exists('result', $result)) {
+			//note that data now is the first element in the array.
+			$result['data'] = $result;
+			$result['result'] = 'success';
+
+			//remove all the keys in $result except 'result'  and 'data'
+			return array_intersect_key($result, array_flip(['result', 'data']));
+		}
 
 		//check returned result of call, if not success then throw an exception with additional information
 		if ($result['result'] !== 'success') {
-			if (!isset($json['data']['code']) || !isset($result['data']['message']))
+			if (!isset($result['data']['code']) || !isset($result['data']['message']))
 				throw new Exception(sprintf('Received unsuccessful state, and additionally a malformed response: %s', var_export($result['data'], true)));
 
 			throw new Exception(sprintf("API request unsuccessful: [%s] %s", $result['data']['code'], $result['data']['message']));


### PR DESCRIPTION
When calling the endpoint "https://api.bl3p.eu/1/BTCEUR/ticker" the response won't have $response['response'], instead returning the data without wrapping it inside a 'data' key. Due to dependencies (like the Bitcoin Ticker Widget, see https://play.google.com/store/apps/details?id=st.brothas.mtgoxwidget&hl=nl) I don't think it's a good idea alter the API code. Instead the $response is manually wrapped in the (almost) correct format.

Note that at line 97 there was a call to an undefined variable $json, changed that to $result.