### PR TITLE
Support GENMKT/money/info call in golang examples

### DIFF
--- a/examples/go/bl3p/bl3p.go
+++ b/examples/go/bl3p/bl3p.go
@@ -109,13 +109,13 @@ func (b Bl3p) requester(call string, params map[string]string) (callModels.Bl3pR
 	res, err := client.Do(r)
 
 	//error handling
-	if res.StatusCode != 200 {
-		return result, fmt.Errorf("Request didn't return a HTTP Status 200 but HTTP Status: %v.", res.StatusCode)
+	if err != nil {
+		return result, err
 	}
 
 	//error handling
-	if err != nil {
-		return result, err
+	if res.StatusCode != 200 {
+		return result, fmt.Errorf("Request didn't return a HTTP Status 200 but HTTP Status: %v.", res.StatusCode)
 	}
 
 	//read request body

--- a/examples/go/bl3p/bl3p.go
+++ b/examples/go/bl3p/bl3p.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/BitonicNL/bl3p-api/examples/go/callModels"
+	"github.com/dfijma/bl3p-api/examples/go/callModels"
 )
 
 //Bl3p struct
@@ -272,6 +272,20 @@ func (b Bl3p) GetLastDepositAddress() (callModels.DepositAddress, error) {
 
 	if err == nil {
 		err = json.Unmarshal(depositAddress.Data, &result)
+	}
+
+	return result, err
+}
+
+//GetInfo | Get account info
+func (b Bl3p) GetInfo() (callModels.Info, error) {
+
+	info, err := b.requester("GENMKT/money/info", nil)
+
+	result := callModels.Info{}
+
+	if err == nil {
+		err = json.Unmarshal(info.Data, &result)
 	}
 
 	return result, err

--- a/examples/go/bl3p/bl3p.go
+++ b/examples/go/bl3p/bl3p.go
@@ -115,7 +115,7 @@ func (b Bl3p) requester(call string, params map[string]string) (callModels.Bl3pR
 
 	//error handling
 	if res.StatusCode != 200 {
-		return result, fmt.Errorf("Request didn't return a HTTP Status 200 but HTTP Status: %v.", res.StatusCode)
+		return result, fmt.Errorf("request didn't return a HTTP Status 200 but HTTP Status: %v", res.StatusCode)
 	}
 
 	//read request body

--- a/examples/go/bl3p/bl3p.go
+++ b/examples/go/bl3p/bl3p.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/dfijma/bl3p-api/examples/go/callModels"
+	"github.com/BitonicNL/bl3p-api/examples/go/callModels"
 )
 
 //Bl3p struct

--- a/examples/go/callModels/callModels.go
+++ b/examples/go/callModels/callModels.go
@@ -105,3 +105,15 @@ type Transaction struct {
 type AddOrder struct {
 	OrderID int64 `json:"order_id"`
 }
+
+//Wallet | Wallet struct
+type Wallet struct {
+	Balance   AmountObj `json:"balance"`
+	Available AmountObj `json:"available"`
+}
+
+//Info | Account call struct
+type Info struct {
+	UserID  int64             `json:"user_id"`
+	Wallets map[string]Wallet `json:"wallets"`
+}

--- a/examples/go/example/example.go
+++ b/examples/go/example/example.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	bl3p "github.com/BitonicNL/bl3p-api/examples/go/bl3p"
+	bl3p "github.com/dfijma/bl3p-api/examples/go/bl3p"
 )
 
 func main() {

--- a/examples/go/example/example.go
+++ b/examples/go/example/example.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	bl3p "github.com/dfijma/bl3p-api/examples/go/bl3p"
+	bl3p "github.com/BitonicNL/bl3p-api/examples/go/bl3p"
 )
 
 func main() {


### PR DESCRIPTION
- support GENMKT/money/info call, returning information on wallets balance and available funds
- fix a small bug in the 'requester' function, which tested the HTTP status code before checking the request itself actually was succesful, which could lead to SIGABRT.

- note, BTW, that the documentation seems to be in error on the result of the API call. It states it contains an "Array" of AmountObj's, one for each wallet. It looks to me to be an "Object", mapping the currency of each wallet to the AmountObj of that wallet:
```
{ 
    "EUR" : <amountObj>,
    "BTC" : <amountObj>,
...
}
```